### PR TITLE
fix typo

### DIFF
--- a/Explore CoDEx.ipynb
+++ b/Explore CoDEx.ipynb
@@ -119,7 +119,7 @@
    "source": [
     "type_id = \"Q5\"\n",
     "print(f\"From {codex.entity_type_wikipedia_url(type_id)}:\")\n",
-    "print(f\" ''{codex.entity_type_extract(type_id)}\"\")"
+    "print(f\"  '{codex.entity_type_extract(type_id)}'\")"
    ]
   },
   {


### PR DESCRIPTION
Uber simple PR:

In the explore CoDEx jupyter notebook, code block 7 has an incorrectly formatted f-string.