### PR TITLE
Fix AttributeError in  Explore CoDEx.ipynb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ codex.csv
 fb.csv
 test.csv
 upload.*
+.idea/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jupyterlab
-matplotlib
+matplotlib<=3.2
 pandas
 seaborn
 tqdm


### PR DESCRIPTION
When following the Explore CoDEx.ipynb step by step at cell 15 with an AttributeError, as a certain method was deprecated in matplotlib 3.2 and later removed (see e.g. here https://github.com/pysal/splot/issues/115)

So to fix this I added a fix for the version in the requirements.txt. This makes the fixes the problem for me.

If you need any further information let me know :)